### PR TITLE
Add the possibility to run custom RSpec and Cucumber commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 This is a lightweight RSpec / Cucumber runner for Vim and MacVim.
 This is based off the original vim-rspec by thoughtbot:
 [vim-rspec](https://github.com/thoughtbot/vim-rspec)
+and forked from Michael Deol's [vim-rspec-cucumber] (https://github.com/michaeldeol/vim-rspec-cucumber)
 
 ## Installation
 
 Recommended installation with [vundle](https://github.com/gmarik/vundle):
 
 ```vim
-Plugin 'michaeldeol/vim-rspec-cucumber'
+Plugin 'bdauria/vim-rspec-cucumber'
 ```
 
 If using zsh on OS X it may be necessary to move `/etc/zshenv` to `/etc/zshrc`.
@@ -27,6 +28,14 @@ map <Leader>s :call RunNearestTest()<CR>
 map <Leader>l :call RunLastTest()<CR>
 map <Leader>a :call RunAllTests()<CR>
 ```
+
+### Custom commands
+You can define custom commands for both RSpec and Cucumber, for instance:
+
+" vim-rspec-cucumber custom commands
+let g:rspec_command = "Dispatch rspec {test}"
+let g:cucumber_command = "Dispatch bundle exec cucumber {test}"
+
 
 ### Custom runners
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ map <Leader>a :call RunAllTests()<CR>
 ### Custom commands
 You can define custom commands for both RSpec and Cucumber, for instance:
 
+```vim
 " vim-rspec-cucumber custom commands
 let g:rspec_command = "Dispatch rspec {test}"
 let g:cucumber_command = "Dispatch bundle exec cucumber {test}"
+```
 
 
 ### Custom runners

--- a/plugin/rspec-cucumber.vim
+++ b/plugin/rspec-cucumber.vim
@@ -14,8 +14,14 @@ endfunction
 
 function! BuildCommand()
   if CheckRSpec()
+    if s:RspecCommandProvided()
+      return g:rspec_command
+    endif
     return "bundle exec rspec --color --format doc {test}"
   elseif CheckCucumber()
+    if s:CucumberCommandProvided()
+      return g:cucumber_command
+    endif
     return "bundle exec cucumber {test}"
   else
     return 0
@@ -82,4 +88,12 @@ endfunction
 
 function! RunTests(test)
   execute substitute(GetCommand(), "{test}", a:test, "g")
+endfunction
+
+function! s:RspecCommandProvided()
+  return exists("g:rspec_command")
+endfunction
+
+function! s:CucumberCommandProvided()
+  return exists("g:cucumber_command")
 endfunction

--- a/plugin/rspec-cucumber.vim
+++ b/plugin/rspec-cucumber.vim
@@ -31,7 +31,9 @@ endfunction
 function! GetCommand()
   let s:cmd = BuildCommand()
 
-  if has("gui_running") && has("gui_macvim")
+  if s:IsCustomCommand(s:cmd)
+    return s:cmd
+  elseif has("gui_running") && has("gui_macvim")
     return "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
   elseif has("win32") && fnamemodify(&shell, ':t') ==? "cmd.exe"
     return "!cls && echo " . s:cmd . " && " . s:cmd
@@ -39,6 +41,7 @@ function! GetCommand()
     return "!clear && echo " . s:cmd . " && " . s:cmd
   endif
 endfunction
+
 
 function! RunAllTests()
   let l:test = ""
@@ -96,4 +99,10 @@ endfunction
 
 function! s:CucumberCommandProvided()
   return exists("g:cucumber_command")
+endfunction
+
+function! s:IsCustomCommand(command)
+  let l:customRspec = s:RspecCommandProvided() && a:command == g:rspec_command
+  let l:customCucumber = s:CucumberCommandProvided() && a:command == g:cucumber_command
+  return l:customRspec || l:customCucumber
 endfunction


### PR DESCRIPTION
This PR basically allows to run RSpec and Cucumber through custom commands, defined in the vimrc. For instance:

let g:rspec_command = "Dispatch bundle exec rspec {test}"
let g:cucumber_command = "Dispatch bundle exec cucumber {test}"

Important note: custom commands are made to be executed in Vim directly, rather than in the shell.
